### PR TITLE
Set default filenames

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -34,12 +34,6 @@ def encrypt_file(filename):
         file.write(encrypted_data)
 
 def main():
-    #Local or remote
-    while True:
-        host = input("Enter server hostname or IP: ")
-        if host != "":
-            break
-
     #File type
     while True:
         file_type = input("File type: Text file(t) or Dictionary(d)? ")
@@ -100,6 +94,8 @@ def main():
     # create a socket object
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) 
 
+    # get local machine name
+    host = socket.gethostname()
     port = 29999
 
     # connection to hostname on the port.

--- a/client/client.py
+++ b/client/client.py
@@ -4,6 +4,8 @@ import json
 import pickle as pk
 import time
 import shutil
+import os
+import sys
 
 # Dictionary 
 data = {
@@ -74,16 +76,19 @@ def main():
     #File encryption - only for text file
     if file_type == "t":
         file_name = "textfile.txt"
-        while True:
-            file_encrypted = input("Encrypt file (y/n)? ")
-            if file_encrypted.lower() == "y":
-                print("File will be encrypted")
-                break
-            elif file_encrypted.lower() == "n":
-                print("File will not be encrypted")
-                break
-            else:
-                print("invalid selection")
+        if os.path.exists(file_name):
+            while True:
+                file_encrypted = input("Encrypt file (y/n)? ")
+                if file_encrypted.lower() == "y":
+                    print("File will be encrypted")
+                    break
+                elif file_encrypted.lower() == "n":
+                    print("File will not be encrypted")
+                    break
+                else:
+                    print("invalid selection")
+        else:
+            sys.exit(file_name + " does not exist.")
     else:
         file_encrypted="n" #default value if dictionary
     

--- a/client/client.py
+++ b/client/client.py
@@ -3,6 +3,7 @@ from cryptography.fernet import Fernet
 import json
 import pickle as pk
 import time
+import shutil
 
 # Dictionary 
 data = {
@@ -23,6 +24,9 @@ def generate_key():
 def encrypt_file(filename):
     key = open("key.key", "rb").read()
     f = Fernet(key)
+    dest = filename + time.strftime("%Y%m%d%H%M%S")
+    shutil.copy(filename, dest)
+    print("Source text file archived to " + dest)
     with open(filename, "rb") as file:
         file_data = file.read()
     encrypted_data = f.encrypt(file_data)
@@ -30,6 +34,12 @@ def encrypt_file(filename):
         file.write(encrypted_data)
 
 def main():
+    #Local or remote
+    while True:
+        host = input("Enter server hostname or IP: ")
+        if host != "":
+            break
+
     #File type
     while True:
         file_type = input("File type: Text file(t) or Dictionary(d)? ")
@@ -46,17 +56,20 @@ def main():
     if file_type == "d":
         while True:
             msg_pickling = print(f"Choose pickling format")
-            msg_pickling = input("1, A\n"
-                    "2, B\n"
-                    "3, C\n"
-                    "Choose 1 for JSON, 2 for Binary format, 3 for XML :")
+            msg_pickling = input("1, JSON\n"
+                    "2, Binary\n"
+                    "3, XML\n"
+                    "Choose 1 for JSON, 2 for Binary format, 3 for XML : ")
             if (str(msg_pickling) == "1"):
+                file_name = "jsonfile.txt"
                 sendmesg = str.encode(json_pick) # pick for JSON format
                 break
             elif (str(msg_pickling) == "2"):
+                file_name = "binaryfile.txt"
                 sendmesg = binary_pick # pick for binary format
                 break
             elif (str(msg_pickling) == "3"):
+                file_name = "xmlfile.txt"
                 sendmesg = xml_pick # pick for XML format
                 break
             else:
@@ -66,6 +79,7 @@ def main():
 
     #File encryption - only for text file
     if file_type == "t":
+        file_name = "textfile.txt"
         while True:
             file_encrypted = input("Encrypt file (y/n)? ")
             if file_encrypted.lower() == "y":
@@ -78,11 +92,6 @@ def main():
                 print("invalid selection")
     else:
         file_encrypted="n" #default value if dictionary
-
-    #File name
-    while True:
-        file_name = input("Enter filename to be sent: ")
-        break
     
     #Encrypt file if required
     if file_encrypted == "y":
@@ -91,19 +100,18 @@ def main():
     # create a socket object
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) 
 
-    # get local machine name
-    host = socket.gethostname()                           
-
     port = 29999
 
     # connection to hostname on the port.
     s.connect((host, port))                               
-    print("Connected")
+    print("Connected to server")
 
     s.send(file_type.encode('utf-8'))
     s.send(msg_pickling.encode('utf-8'))
     s.send(file_encrypted.encode('utf-8'))
     s.send(file_name.encode('utf-8'))
+
+    time.sleep(2)
 
     if file_type == "t":
         file = open(file_name,'rb')
@@ -113,7 +121,6 @@ def main():
             data = file.read(1024)
         file.close()
     elif file_type == "d":
-        time.sleep(2)
         print("Pickled data: " + str(sendmesg))
         s.send(sendmesg)
 

--- a/client/client.py
+++ b/client/client.py
@@ -6,6 +6,7 @@ import time
 import shutil
 import os
 import sys
+from xml.etree.ElementTree import Element, tostring
 
 # Dictionary 
 data = {
@@ -16,7 +17,11 @@ data = {
 
 json_pick = json.dumps(data) # for pickling JSON format 
 binary_pick = pk.dumps(data) # for picking binary format
-xml_pick = 1
+xml_pick = Element('data') # to change the data dictionary to an xml file
+for key, value in data.items(): # changing the data into keys and values
+    child_node = Element(key)
+    child_node.text = value
+    xml_pick.append(child_node)
 
 def generate_key():
     key = Fernet.generate_key()
@@ -66,7 +71,7 @@ def main():
                 break
             elif (str(msg_pickling) == "3"):
                 file_name = "xmlfile.txt"
-                sendmesg = xml_pick # pick for XML format
+                sendmesg = tostring(xml_pick) # pick for XML format
                 break
             else:
                 print("invalid selection")

--- a/client/textfile.txt
+++ b/client/textfile.txt
@@ -1,0 +1,2 @@
+Text file line 1
+Text file line 2

--- a/server/server.py
+++ b/server/server.py
@@ -60,7 +60,7 @@ def main():
                 socket.AF_INET, socket.SOCK_STREAM)
 
     # get local machine name
-    host = socket.gethostname()                           
+    host = '0.0.0.0' #accept all ip's                          
     port = 29999                                           
 
     # bind to the port

--- a/server/server.py
+++ b/server/server.py
@@ -60,7 +60,7 @@ def main():
                 socket.AF_INET, socket.SOCK_STREAM)
 
     # get local machine name
-    host = '0.0.0.0' #accept all ip's                          
+    host = socket.gethostname()                           
     port = 29999                                           
 
     # bind to the port


### PR DESCRIPTION
Create a copy of text file with timestamp before encrypting it.
Added default filenames for JSON, binary, XML, and text files. No need to manually enter filename anymore.
Added validation that textfile exists else exit program.